### PR TITLE
Add simple support for Kleisli[Id, SparkContext, A].

### DIFF
--- a/src/main/scala/cats/bec/SparkTask.scala
+++ b/src/main/scala/cats/bec/SparkTask.scala
@@ -1,0 +1,13 @@
+package cats
+package bec
+
+import cats.data.Kleisli
+import org.apache.spark.SparkContext
+
+object SparkTask {
+  def apply[A](f: SparkContext => A): SparkTask[A] =
+    Kleisli[Id, SparkContext, A](f)
+
+  def pure[A](a: => A): SparkTask[A] =
+    Kleisli[Id, SparkContext, A](_ => a)
+}

--- a/src/main/scala/cats/bec/package.scala
+++ b/src/main/scala/cats/bec/package.scala
@@ -1,0 +1,8 @@
+package cats
+
+import cats.data.Kleisli
+import org.apache.spark.SparkContext
+
+package object bec {
+  type SparkTask[A] = Kleisli[Id, SparkContext, A]
+}


### PR DESCRIPTION
This commit was proposed by Adelbert Chang to make working with
Spark a bit nicer. The reader pattern is designed for exactly
the situation that SparkContext is used in, so we can easily
support it this way.

Examples:

  val st0: SparkTask[A] =
    SparkTask { sc =>
      // code using SparkContext
      ...
    }

  val st1: SparkTask[Int] =
    SparkTask.pure(333)

SparkTask[A] is an alias for Kleisli[Id, SparkContext, A]
along with a companion object (as shown above).
